### PR TITLE
Gulp4 compat to prevent fatal errors on upload

### DIFF
--- a/index.js
+++ b/index.js
@@ -286,8 +286,11 @@ module.exports = function (options) {
                 var highWaterMark = stream.highWaterMark||(16*1000);
                 var size = file.stat.size;
 
-
-                file.pipe(stream); // start upload
+                if ( file.isStream() ) {
+                    file.contents.pipe( stream );
+                } else if ( file.isBuffer() ) {
+                    stream.end( file.contents );
+                }
 
                 stream.on('drain',function(){
                     uploadedBytes+=highWaterMark;


### PR DESCRIPTION
Implements [this fix](https://github.com/gtg092x/gulp-sftp/issues/78#issuecomment-356475605) to prevent file uploads from causing fatal errors.