### PR TITLE
Replace Iconic/IconicWP branding with Kadence

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "version": "0.1.8",
   "description": "Upload files via SSH",
   "license": "MIT",
-  "repository": "https://github.com/iconicwp/gulp-sftp",
-  "homepage": "https://github.com/iconicwp/gulp-sftp",
+  "repository": "https://github.com/stellarwp/kadence-gulp-sftp",
+  "homepage": "https://github.com/stellarwp/kadence-gulp-sftp",
   "bugs": {
-    "url": "https://github.com/iconicwp/gulp-sftp/issues"
+    "url": "https://github.com/stellarwp/kadence-gulp-sftp/issues"
   },
   "author": {
     "name": "Matthew Drake",


### PR DESCRIPTION
## Summary

Automated brand migration from Iconic/IconicWP to Kadence.

### Changed
- Brand references in package.json updated from Iconic/IconicWP to Kadence
- GitHub org/repo references updated

### Preserved
- PHP identifiers, CSS class/ID names, file and directory names
- Text domains, non-GitHub URLs, email addresses